### PR TITLE
Handle TiDB decimal price decoding

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -28,7 +28,7 @@ export default function Footer() {
                     <a
                       href={link.href}
                       target={newTab ? "_blank" : undefined}
-                      rel={newTab ? "noopener noreferrer" : undefined}
+                      rel="noreferrer"
                       className="hover:underline"
                     >
                       {link.title}

--- a/components/v2/Footer.tsx
+++ b/components/v2/Footer.tsx
@@ -45,7 +45,7 @@ export default function Footer() {
                     <a
                       href={link.href}
                       target={isHttp ? "_blank" : undefined}
-                      rel={isHttp ? "noopener noreferrer" : undefined}
+                      rel="noreferrer"
                       className="hover:underline"
                     >
                       {link.title}

--- a/lib/sync/tidb.ts
+++ b/lib/sync/tidb.ts
@@ -52,6 +52,7 @@ function buildPool(): Pool {
     database,
     waitForConnections: true,
     connectionLimit: 5,
+    decimalNumbers: true,
     ssl: ca
       ? {
           ca,

--- a/lib/sync/transform.ts
+++ b/lib/sync/transform.ts
@@ -92,6 +92,13 @@ export function transformRow(row: TiDBProductRow): TransformResult {
   }
 
   const updatedAt = coerceDate(row.updated_at);
+  const rawPrice = row.price;
+  const hasPrice =
+    rawPrice !== null &&
+    rawPrice !== undefined &&
+    !(typeof rawPrice === 'string' && rawPrice.trim() === '');
+  const coercedPrice = hasPrice ? Number(rawPrice) : undefined;
+  const price = typeof coercedPrice === 'number' && !Number.isNaN(coercedPrice) ? coercedPrice : undefined;
   const product: ProductDTO = {
     objectID,
     sku: sku || String(row.id),
@@ -101,7 +108,7 @@ export function transformRow(row: TiDBProductRow): TransformResult {
     brand: row.brand?.trim() || undefined,
     shortDescription: row.short_description || undefined,
     longDescription: row.long_description || undefined,
-    price: typeof row.price === 'number' ? row.price : undefined,
+    price,
     currency: row.currency?.trim() || undefined,
     categories: normalizeCategories(row.categories),
     attributes: normalizeAttributes(row.attributes),
@@ -122,7 +129,7 @@ export function transformRow(row: TiDBProductRow): TransformResult {
     product.stockStatus = product.stockQty && product.stockQty > 0 ? 'instock' : 'outofstock';
   }
 
-  if (!product.price) {
+  if (price === undefined) {
     warnings.push(`Product ${row.id} has no price. It will be indexed without price.`);
   }
 

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -13,7 +13,7 @@ export type TiDBProductRow = {
   brand: string | null;
   short_description: string | null;
   long_description: string | null;
-  price: number | null;
+  price: number | string | null;
   currency: string | null;
   categories: string | null;
   attributes: string | null;


### PR DESCRIPTION
## Summary
- enable numeric decoding of TiDB DECIMAL columns by setting `decimalNumbers: true` on the MySQL pool
- coerce product prices from TiDB to numbers, tighten the row typing, and only warn when a numeric price is unavailable
- ensure footer external links always include `rel="noreferrer"` so Next.js lint passes during builds

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68df8c5e4aac8323b96d38b8c2bfaf4a